### PR TITLE
fix: use full UUID v4 for subscription IDs

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,8 +11,6 @@ use crate::store::Store;
 const SOCK_NAME: &str = "daemon.sock";
 const TICK_INTERVAL_SECS: u64 = 2;
 const GITHUB_INTERVAL_SECS: u64 = 60;
-const PRUNE_INTERVAL_SECS: u64 = 3600;
-const PRUNE_AGE_SECS: i64 = 7 * 86400; // 7 days
 
 /// Check if the daemon is already running by trying to connect to the Unix socket.
 pub fn is_running() -> bool {
@@ -135,30 +133,9 @@ pub async fn run(_args: DaemonArgs) -> Result<()> {
 
     let client = GhCliClient;
     let mut last_check: HashMap<String, Instant> = HashMap::new();
-    let mut last_prune = Instant::now();
-
-    // Prune old completed subscriptions on startup
-    if let Ok(db) = Store::open_default() {
-        match db.prune_completed(PRUNE_AGE_SECS) {
-            Ok(n) if n > 0 => tracing::info!(count = n, "Pruned old completed subscriptions"),
-            _ => {}
-        }
-    }
-
     loop {
         if let Err(e) = poll_cycle(&mut last_check, &client).await {
             tracing::error!(error = %e, "Poll cycle error");
-        }
-
-        // Periodic pruning
-        if last_prune.elapsed() >= Duration::from_secs(PRUNE_INTERVAL_SECS) {
-            last_prune = Instant::now();
-            if let Ok(db) = Store::open_default() {
-                match db.prune_completed(PRUNE_AGE_SECS) {
-                    Ok(n) if n > 0 => tracing::info!(count = n, "Pruned old completed subscriptions"),
-                    _ => {}
-                }
-            }
         }
 
         sleep(Duration::from_secs(TICK_INTERVAL_SECS)).await;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,6 +11,8 @@ use crate::store::Store;
 const SOCK_NAME: &str = "daemon.sock";
 const TICK_INTERVAL_SECS: u64 = 2;
 const GITHUB_INTERVAL_SECS: u64 = 60;
+const PRUNE_INTERVAL_SECS: u64 = 3600;
+const PRUNE_AGE_SECS: i64 = 7 * 86400; // 7 days
 
 /// Check if the daemon is already running by trying to connect to the Unix socket.
 pub fn is_running() -> bool {
@@ -133,11 +135,32 @@ pub async fn run(_args: DaemonArgs) -> Result<()> {
 
     let client = GhCliClient;
     let mut last_check: HashMap<String, Instant> = HashMap::new();
+    let mut last_prune = Instant::now();
+
+    // Prune old completed subscriptions on startup
+    if let Ok(db) = Store::open_default() {
+        match db.prune_completed(PRUNE_AGE_SECS) {
+            Ok(n) if n > 0 => tracing::info!(count = n, "Pruned old completed subscriptions"),
+            _ => {}
+        }
+    }
 
     loop {
         if let Err(e) = poll_cycle(&mut last_check, &client).await {
             tracing::error!(error = %e, "Poll cycle error");
         }
+
+        // Periodic pruning
+        if last_prune.elapsed() >= Duration::from_secs(PRUNE_INTERVAL_SECS) {
+            last_prune = Instant::now();
+            if let Ok(db) = Store::open_default() {
+                match db.prune_completed(PRUNE_AGE_SECS) {
+                    Ok(n) if n > 0 => tracing::info!(count = n, "Pruned old completed subscriptions"),
+                    _ => {}
+                }
+            }
+        }
+
         sleep(Duration::from_secs(TICK_INTERVAL_SECS)).await;
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -153,19 +153,6 @@ impl Store {
         Ok(rows)
     }
 
-    /// Delete fired/expired/cancelled subscriptions older than `older_than_secs` seconds.
-    /// Returns the number of rows deleted.
-    pub fn prune_completed(&self, older_than_secs: i64) -> Result<usize> {
-        let cutoff = chrono::Utc::now().timestamp() - older_than_secs;
-        let rows = self.conn.execute(
-            "DELETE FROM subscriptions
-             WHERE status IN ('fired', 'expired', 'cancelled')
-               AND created_at < ?1",
-            params![cutoff],
-        )?;
-        Ok(rows)
-    }
-
     pub fn status_counts(&self) -> Result<StatusCounts> {
         let mut stmt = self.conn.prepare(
             "SELECT status, COUNT(*) FROM subscriptions GROUP BY status",
@@ -370,58 +357,6 @@ mod tests {
         store.insert(&sub1).unwrap();
         let result = store.insert(&sub2);
         assert!(result.is_err(), "Expected error on duplicate ID insert");
-        assert!(
-            result.unwrap_err().to_string().contains("UNIQUE constraint failed"),
-            "Expected UNIQUE constraint error"
-        );
-    }
-
-    #[test]
-    fn test_prune_completed() {
-        // T4: Prune old fired/expired/cancelled subs, keep active ones
-        let store = Store::open(":memory:").unwrap();
-
-        // Insert an active sub with old timestamp
-        let mut active_sub = timer_sub("active-old");
-        active_sub.created_at = 1000;
-        store.insert(&active_sub).unwrap();
-
-        // Insert fired sub with old timestamp
-        let mut fired_sub = timer_sub("fired-old");
-        fired_sub.status = "fired".into();
-        fired_sub.created_at = 1000;
-        store.insert(&fired_sub).unwrap();
-
-        // Insert expired sub with old timestamp
-        let mut expired_sub = timer_sub("expired-old");
-        expired_sub.status = "expired".into();
-        expired_sub.created_at = 1000;
-        store.insert(&expired_sub).unwrap();
-
-        // Insert cancelled sub with old timestamp
-        let mut cancelled_sub = timer_sub("cancelled-old");
-        cancelled_sub.status = "cancelled".into();
-        cancelled_sub.created_at = 1000;
-        store.insert(&cancelled_sub).unwrap();
-
-        // Insert a recent fired sub (should NOT be pruned)
-        let mut recent_fired = timer_sub("fired-recent");
-        recent_fired.status = "fired".into();
-        recent_fired.created_at = chrono::Utc::now().timestamp();
-        store.insert(&recent_fired).unwrap();
-
-        // Prune subs older than 1 day
-        let pruned = store.prune_completed(86400).unwrap();
-        assert_eq!(pruned, 3, "Should prune 3 old completed subs");
-
-        // Active sub should still exist
-        assert!(store.get("active-old").unwrap().is_some());
-        // Recent fired sub should still exist
-        assert!(store.get("fired-recent").unwrap().is_some());
-        // Old completed subs should be gone
-        assert!(store.get("fired-old").unwrap().is_none());
-        assert!(store.get("expired-old").unwrap().is_none());
-        assert!(store.get("cancelled-old").unwrap().is_none());
     }
 
     #[test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -153,6 +153,19 @@ impl Store {
         Ok(rows)
     }
 
+    /// Delete fired/expired/cancelled subscriptions older than `older_than_secs` seconds.
+    /// Returns the number of rows deleted.
+    pub fn prune_completed(&self, older_than_secs: i64) -> Result<usize> {
+        let cutoff = chrono::Utc::now().timestamp() - older_than_secs;
+        let rows = self.conn.execute(
+            "DELETE FROM subscriptions
+             WHERE status IN ('fired', 'expired', 'cancelled')
+               AND created_at < ?1",
+            params![cutoff],
+        )?;
+        Ok(rows)
+    }
+
     pub fn status_counts(&self) -> Result<StatusCounts> {
         let mut stmt = self.conn.prepare(
             "SELECT status, COUNT(*) FROM subscriptions GROUP BY status",
@@ -320,6 +333,95 @@ mod tests {
         // After expiration, set_fired should return false
         let fired = store.set_fired("test-fire-active", &serde_json::json!({})).unwrap();
         assert!(!fired);
+    }
+
+    #[test]
+    fn test_store_insert_get_roundtrip_full_uuid() {
+        // T2: Insert with full UUID, retrieve, verify round-trip
+        let store = Store::open(":memory:").unwrap();
+        let id = uuid::Uuid::new_v4().to_string();
+        let sub = Subscription {
+            id: id.clone(),
+            source: "timer".into(),
+            condition: Condition::Timer { duration: "10m".into(), fire_at: 99999999999 },
+            mode: "wait".into(),
+            callback: None,
+            status: "active".into(),
+            created_at: 1000,
+            expires_at: None,
+            event_data: None,
+        };
+        store.insert(&sub).unwrap();
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.source, "timer");
+        assert_eq!(got.status, "active");
+        assert_eq!(got.mode, "wait");
+        // Verify the ID is a full UUID (36 chars with hyphens)
+        assert_eq!(id.len(), 36);
+    }
+
+    #[test]
+    fn test_store_insert_duplicate_id_rejected() {
+        // T3: Two subscriptions with identical IDs should fail on second insert
+        let store = Store::open(":memory:").unwrap();
+        let sub1 = timer_sub("duplicate-id");
+        let sub2 = timer_sub("duplicate-id");
+        store.insert(&sub1).unwrap();
+        let result = store.insert(&sub2);
+        assert!(result.is_err(), "Expected error on duplicate ID insert");
+        assert!(
+            result.unwrap_err().to_string().contains("UNIQUE constraint failed"),
+            "Expected UNIQUE constraint error"
+        );
+    }
+
+    #[test]
+    fn test_prune_completed() {
+        // T4: Prune old fired/expired/cancelled subs, keep active ones
+        let store = Store::open(":memory:").unwrap();
+
+        // Insert an active sub with old timestamp
+        let mut active_sub = timer_sub("active-old");
+        active_sub.created_at = 1000;
+        store.insert(&active_sub).unwrap();
+
+        // Insert fired sub with old timestamp
+        let mut fired_sub = timer_sub("fired-old");
+        fired_sub.status = "fired".into();
+        fired_sub.created_at = 1000;
+        store.insert(&fired_sub).unwrap();
+
+        // Insert expired sub with old timestamp
+        let mut expired_sub = timer_sub("expired-old");
+        expired_sub.status = "expired".into();
+        expired_sub.created_at = 1000;
+        store.insert(&expired_sub).unwrap();
+
+        // Insert cancelled sub with old timestamp
+        let mut cancelled_sub = timer_sub("cancelled-old");
+        cancelled_sub.status = "cancelled".into();
+        cancelled_sub.created_at = 1000;
+        store.insert(&cancelled_sub).unwrap();
+
+        // Insert a recent fired sub (should NOT be pruned)
+        let mut recent_fired = timer_sub("fired-recent");
+        recent_fired.status = "fired".into();
+        recent_fired.created_at = chrono::Utc::now().timestamp();
+        store.insert(&recent_fired).unwrap();
+
+        // Prune subs older than 1 day
+        let pruned = store.prune_completed(86400).unwrap();
+        assert_eq!(pruned, 3, "Should prune 3 old completed subs");
+
+        // Active sub should still exist
+        assert!(store.get("active-old").unwrap().is_some());
+        // Recent fired sub should still exist
+        assert!(store.get("fired-recent").unwrap().is_some());
+        // Old completed subs should be gone
+        assert!(store.get("fired-old").unwrap().is_none());
+        assert!(store.get("expired-old").unwrap().is_none());
+        assert!(store.get("cancelled-old").unwrap().is_none());
     }
 
     #[test]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -379,6 +379,23 @@ mod tests {
     }
 
     #[test]
+    fn test_from_on_args_generates_full_uuid() {
+        use crate::cli::OnArgs;
+        let args = OnArgs {
+            source: "timer".into(),
+            args: vec!["30m".into()],
+            run: "echo hello".into(),
+            timeout: None,
+            repo: None,
+        };
+        let sub = Subscription::from_on_args(&args).unwrap();
+        // Full UUID v4 is 36 chars with hyphens (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+        assert_eq!(sub.id.len(), 36, "ID should be a full UUID, got: {}", sub.id);
+        // Verify it parses as a valid UUID
+        uuid::Uuid::parse_str(&sub.id).expect("ID should be a valid UUID");
+    }
+
+    #[test]
     fn test_condition_summary() {
         let sub = Subscription {
             id: "x".into(),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -363,6 +363,22 @@ mod tests {
     }
 
     #[test]
+    fn test_from_wait_args_generates_full_uuid() {
+        use crate::cli::WaitArgs;
+        let args = WaitArgs {
+            source: "timer".into(),
+            args: vec!["30m".into()],
+            timeout: None,
+            repo: None,
+        };
+        let sub = Subscription::from_wait_args(&args).unwrap();
+        // Full UUID v4 is 36 chars with hyphens (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+        assert_eq!(sub.id.len(), 36, "ID should be a full UUID, got: {}", sub.id);
+        // Verify it parses as a valid UUID
+        uuid::Uuid::parse_str(&sub.id).expect("ID should be a valid UUID");
+    }
+
+    #[test]
     fn test_condition_summary() {
         let sub = Subscription {
             id: "x".into(),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -63,7 +63,7 @@ impl Subscription {
             .map(|d| Utc::now().timestamp() + d);
 
         Ok(Self {
-            id: uuid::Uuid::new_v4().to_string()[..8].to_string(),
+            id: uuid::Uuid::new_v4().to_string(),
             source: condition.source_name().to_string(),
             condition,
             mode: "wait".into(),
@@ -81,7 +81,7 @@ impl Subscription {
             .map(|d| Utc::now().timestamp() + d);
 
         Ok(Self {
-            id: uuid::Uuid::new_v4().to_string()[..8].to_string(),
+            id: uuid::Uuid::new_v4().to_string(),
             source: condition.source_name().to_string(),
             condition,
             mode: "on".into(),
@@ -348,6 +348,18 @@ mod tests {
             let json2 = serde_json::to_string(&parsed).unwrap();
             assert_eq!(json, json2, "roundtrip failed for: {json}");
         }
+    }
+
+    #[test]
+    fn test_subscription_id_uniqueness() {
+        use std::collections::HashSet;
+        // T1: Generate 10,000 subscriptions and verify all IDs are unique
+        let mut ids = HashSet::new();
+        for _ in 0..10_000 {
+            let id = uuid::Uuid::new_v4().to_string();
+            assert!(ids.insert(id), "Duplicate subscription ID generated");
+        }
+        assert_eq!(ids.len(), 10_000);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3

## Summary
- Replace truncated 8-char UUID prefix (32 bits entropy) with full UUID v4 (122 bits) in subscription ID generation, eliminating collision risk
- Add `prune_completed()` to Store that deletes fired/expired/cancelled subscriptions older than 7 days, preventing unbounded table growth
- Add periodic pruning in the daemon (on startup + every hour)
- Add tests: ID uniqueness (10k IDs), store round-trip with full UUIDs, duplicate ID rejection, and pruning correctness

## Test plan
- [x] All 43 unit tests pass (`cargo test`)
- [x] `cargo clippy` clean
- [x] Verify-only: 100 generated IDs match UUID v4 regex
- [x] Verify-only: 50,000 SQLite insertions with full UUIDs, zero collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)